### PR TITLE
Ett 381 rabbit mq tests

### DIFF
--- a/app/ht_indexer/src/document_generator/document_generator_service.py
+++ b/app/ht_indexer/src/document_generator/document_generator_service.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from full_text_document_generator import FullTextDocumentGenerator
 from generator_arguments import GeneratorServiceArguments
 from ht_document.ht_document import HtDocument
-from ht_queue_service.queue_consumer import QueueConsumer, positive_acknowledge
+from ht_queue_service.queue_consumer import QueueConsumer
 from ht_queue_service.queue_producer import QueueProducer
 from ht_utils.ht_logger import get_ht_logger
 from ht_utils.ht_utils import get_error_message_by_document, get_general_error_message
@@ -85,7 +85,7 @@ class DocumentGeneratorService:
                                                                      e, document)
 
         logger.error(f"Document {document.get('ht_id')} failed {error_info}")
-        self.src_queue_consumer.reject_message(self.src_queue_consumer.conn.ht_channel,
+        self.src_queue_consumer.reject_message(self.src_queue_consumer.ht_channel,
                                                delivery_tag)
 
     def consume_messages(self):
@@ -110,7 +110,7 @@ class DocumentGeneratorService:
             self.publish_document(full_text_document)
             # Acknowledge the message to src_queue if the message is processed successfully and published in
             # the other queue
-            positive_acknowledge(self.src_queue_consumer.conn.ht_channel,
+            self.src_queue_consumer.positive_acknowledge(self.src_queue_consumer.ht_channel,
                                  delivery_tag)
         except Exception as e:
             self.log_error_document_generator_service(e, message, delivery_tag)

--- a/app/ht_indexer/src/document_indexer_service/indexer_arguments.py
+++ b/app/ht_indexer/src/document_indexer_service/indexer_arguments.py
@@ -51,6 +51,8 @@ class IndexerServiceArguments:
             "queue_host": os.getenv("QUEUE_HOST"),
             "queue_name": os.getenv("QUEUE_NAME") if os.getenv("QUEUE_NAME") else indexer_queue_name,
             "requeue_message": indexer_requeue_message,
-            "batch_size": int(self.args.batch_size) if self.args.batch_size else indexer_batch_size
+            "batch_size": int(self.args.batch_size) if self.args.batch_size else indexer_batch_size,
+            "shutdown_on_empty_queue": False  # The indexer process is a long-running service
+                # that does not stop when the queue is empty.
         }
 

--- a/app/ht_indexer/src/document_retriever_service/full_text_search_retriever_service.py
+++ b/app/ht_indexer/src/document_retriever_service/full_text_search_retriever_service.py
@@ -343,15 +343,14 @@ def main():
             # Create a connection to the queue to produce messages
             queue_producer = document_retriever_service.get_queue_producer()
 
-            total_messages_in_queue = queue_producer.conn.get_total_messages()
+            total_messages_in_queue = queue_producer.get_total_messages()
 
             while total_messages_in_queue > MAX_DOCUMENT_IN_QUEUE:
                 logger.info (f"Waiting: There are {total_messages_in_queue} or more documents in the {queue_producer.queue_name}")
                 time.sleep(WAITING_TIME_QUEUE_PRODUCER) # Wait 5 minutes to send documents in the queue
-                total_messages_in_queue = queue_producer.conn.get_total_messages()
+                total_messages_in_queue = queue_producer.get_total_messages()
                 total_time_waiting += WAITING_TIME_QUEUE_PRODUCER
-            queue_producer.conn.queue_connection.close()
-
+            queue_producer.close()
 
 
 if __name__ == "__main__":

--- a/app/ht_indexer/src/ht_queue_service/queue_connection.py
+++ b/app/ht_indexer/src/ht_queue_service/queue_connection.py
@@ -1,4 +1,9 @@
 import pika
+import pika.exceptions
+
+from ht_utils.ht_logger import get_ht_logger
+
+logger = get_ht_logger(name=__name__)
 
 # Calculate the maximum number of messages in the queue
 
@@ -19,50 +24,99 @@ class QueueConnection:
 
     def __init__(self, user: str, password: str, host: str, queue_name: str, batch_size: int = 1):
         # Define credentials (user/password) as environment variables
-        # declaring the credentials needed for connection like host, port, username, password, exchange etc.
+        # Declaring the credentials needed for connection, such as host, port, username, password, and exchange.
 
-        try:
-            self.credentials = pika.PlainCredentials(username=user, password=password)
+        self.credentials = pika.PlainCredentials(username=user, password=password)
 
-            self.host = host
-            self.queue_name = queue_name
-            self.exchange = 'ht_channel'
-            self.batch_size = batch_size
+        self.user = user
+        self.password = password
+        self.host = host
+        self.queue_name = queue_name
+        # TODO: make the exchange name configurable
+        self.exchange = 'ht_channel'
+        self.batch_size = batch_size
+        self._connect()
 
-            # Open a connection to RabbitMQ
-            self.queue_connection = pika.BlockingConnection(pika.ConnectionParameters(host=self.host,
-                                                                                      credentials=self.credentials,
-                                                                                      heartbeat=0))
-            self.ht_channel = self.ht_queue_connection()
-        except Exception as e:
-            raise e
+    def _connect(self):
+        self.queue_connection = pika.BlockingConnection(
+            pika.ConnectionParameters(host=self.host, credentials=self.credentials, heartbeat=0)
+        )
+        self.ht_channel = self.ht_queue_connection()
 
     def ht_queue_connection(self):
-        # queue a name is important when you want to share the queue between producers and consumers
 
-        # channel - a channel is a virtual connection inside a connection
-        # get a channel
+        """
+        A Queue name is important when you want to share the queue between producers and consumers
+        channel - a channel is a virtual connection inside a connection
+
+        exchange - this can be assumed as a bridge name that needed to be declared so that queues can be accessed
+        Direct – the exchange forwards the message to a queue based on a routing key
+
+        The value defines the maximum number of unacknowledged deliveries that are permitted on a channel.
+        When the number reaches the configured count, RabbitMQ will stop delivering more messages on the
+        channel until at least one of the outstanding ones is acknowledged.
+        """
+        # Get a channel
         ht_channel = self.queue_connection.channel()
 
-        # exchange - this can be assumed as a bridge name which needed to be declared so that queues can be accessed
         # declare the exchange
-        # Direct – the exchange forwards the message to a queue based on a routing key
         ht_channel.exchange_declare(self.exchange, durable=True, exchange_type="direct", auto_delete=False)
 
-        ht_channel.queue_bind(self.queue_name, self.exchange, routing_key=self.queue_name)
-
-        # The value defines the max number of unacknowledged deliveries that are permitted on a channel.
-        # When the number reaches the configured count, RabbitMQ will stop delivering more messages on the
-        # channel until at least one of the outstanding ones is acknowledged.
         ht_channel.basic_qos(prefetch_count=self.batch_size)
 
         return ht_channel
 
     def queue_reconnect(self):
-        self.__init__(self.credentials.username, self.credentials.password, self.host, self.queue_name)
 
-    def get_total_messages(self):
-        # durable: Survive reboots of the broker
-        # passive: Only check to see if the queue exists and raise `ChannelClosed` if it doesn't
-        status = self.ht_channel.queue_declare(self.queue_name, durable=True, passive=True)
-        return status.method.message_count
+        """ Reconnect to RabbitMQ server """
+
+        logger.info(f"Reconnecting to RabbitMQ at {self.host}")
+        try:
+            if self.queue_connection and not self.queue_connection.is_closed:
+                self.queue_connection.close()
+        except Exception:
+            pass
+        self._connect()
+
+    def close(self):
+        """ Close the connection to RabbitMQ server """
+        try:
+            if self.queue_connection and not self.queue_connection.is_closed:
+                self.queue_connection.close()
+        except Exception as e:
+            logger.warning(f"Error closing RabbitMQ connection: {e}")
+
+    def is_ready(self) -> bool:
+        return self.queue_connection and self.ht_channel and not self.ht_channel.is_closed
+
+    def get_total_messages(self) -> int:
+        try:
+            # Ensure a channel is open
+            if not self.is_ready():
+                self.queue_reconnect()
+
+            # Use passive=True to avoid creating a queue if it doesn't exist
+            status = self.ht_channel.queue_declare(
+                queue=self.queue_name, durable=True, passive=True
+            )
+            return status.method.message_count
+        # This exception will catch the issue when the queue does not exist or the queue
+        #is declared with different arguments or some permission issue.
+        except pika.exceptions.ChannelClosedByBroker as e:
+            logger.warning(f"Queue '{self.queue_name}' does not exist: {e}")
+            self.queue_reconnect()
+            return 0
+        # This exception will catch all the issue related to the AMQP protocol (Advanced Message Queuing Protocol)
+        # Something went wrong at the protocol level, but pika cannot provide a
+        # more specific exception
+        except pika.exceptions.AMQPError as e:
+            logger.error(f"Failed to get message count for queue '{self.queue_name}': {e}")
+            self.queue_reconnect()
+            return 0
+
+        except Exception as e:
+            logger.exception(
+                f"Unexpected error while counting messages in queue '{self.queue_name}': {e}"
+            )
+            self.queue_reconnect()
+            return 0

--- a/app/ht_indexer/src/ht_queue_service/queue_connection_dead_letter.py
+++ b/app/ht_indexer/src/ht_queue_service/queue_connection_dead_letter.py
@@ -37,7 +37,7 @@ class QueueConnectionDeadLetter(QueueConnection):
         # get a channel
         ht_channel = self.queue_connection.channel()
 
-        # exchange - this can be assumed as a bridge name which needed to be declared so that queues can be accessed
+        # exchange - this can be assumed as a bridge name which needs to be declared so that queues can be accessed
         # declare the exchange
         # Direct – the exchange forwards the message to a queue based on a routing key
         ht_channel.exchange_declare(self.exchange, durable=True, exchange_type="direct", auto_delete=False)
@@ -53,14 +53,14 @@ class QueueConnectionDeadLetter(QueueConnection):
 
         # Bind the dead letter exchange to the dead letter queue
         # The queue_bind method binds a queue to an exchange. The queue will now receive messages from the exchange,
-        # otherwise no messages will be routed to the queue.
+        # Otherwise, no messages will be routed to the queue.
         ht_channel.queue_bind(f"{self.queue_name}_dead_letter_queue", "dlx", f"dlx_key_{self.queue_name}")
 
         # The relationship between exchange and a queue is called a binding.
         # Link the exchange to the queue to send messages.
         ht_channel.queue_bind(self.queue_name, self.exchange, routing_key=self.queue_name)
 
-        # The value defines the max number of unacknowledged deliveries that are permitted on a channel.
+        # The value defines the maximum number of unacknowledged deliveries that are permitted on a channel.
         # When the number reaches the configured count, RabbitMQ will stop delivering more messages on the
         # channel until at least one of the outstanding ones is acknowledged.
         ht_channel.basic_qos(prefetch_count=self.batch_size)

--- a/app/ht_indexer/src/ht_queue_service/queue_consumer.py
+++ b/app/ht_indexer/src/ht_queue_service/queue_consumer.py
@@ -1,46 +1,49 @@
 # consumer
+from ht_queue_service.queue_connection import QueueConnection
 from ht_utils.ht_logger import get_ht_logger
 
 from ht_queue_service.queue_connection_dead_letter import QueueConnectionDeadLetter
 
 logger = get_ht_logger(name=__name__)
 
-
-def positive_acknowledge(used_channel, basic_deliver):
-    used_channel.basic_ack(delivery_tag=basic_deliver)
-
-
-class QueueConsumer:
+class QueueConsumer(QueueConnection):
     def __init__(self, user: str, password: str, host: str, queue_name: str,
                  requeue_message: bool = False, batch_size: int = None):
 
         """
         This class is used to consume messages from the queue
-        :param user: username for the RabbitMQ
-        :param password: password for the RabbitMQ
-        :param host: host for the RabbitMQ
-        :param queue_name: name of the queue
-        :param requeue_message: boolean to requeue the message to the queue
+        : param user: username for the RabbitMQ
+        : param password: password for the RabbitMQ
+        : param host: host for the RabbitMQ
+        : param queue_name: name of the queue
+        : param requeue_message: boolean to requeue the message to the queue
+        : param batch_size: size of the batch to be consumed
         """
 
-        # Credentials (user/password) are defined as environment variables
-        # declaring the credentials needed for connection like host, port, username, password, exchange etc.
-        self.user = user
-        self.host = host
-        self.queue_name = queue_name
-        self.password = password
+        super().__init__(user, password, host, queue_name, batch_size if batch_size else 1)
         self.requeue_message = requeue_message
 
         try:
-            self.conn = QueueConnectionDeadLetter(self.user, self.password, self.host, self.queue_name, batch_size)
+            self.dlq_conn = QueueConnectionDeadLetter(self.user, self.password, self.host, self.queue_name, batch_size)
         except Exception as e:
-            raise e
+            logger.error(f"Failed to establish RabbitMQ connection: {e}")
+            raise
 
     def consume_message(self, inactivity_timeout: int = None) -> dict or None:
+        """
+        This method consumes messages from the queue.
+        : param inactivity_timeout: time in seconds to wait for a message before returning None
 
+        :return: a generator that yields a dictionary with the method_frame, properties, and body of the message.
+        Always ask if method_frame is None when you use this function
+        We use channel.consume() to consume messages from the queue.
+        RabbitMQ registers the process, creating a consumer tag as an identifier for the consumer.
+        This register is active until you cancel the consumer or close the channel/connection,
+        Add a finally block to close the connection.
+        """
         # Inactivity timeout is the time in seconds to wait for a message before returning None, the consumer will
         try:
-            for method_frame, properties, body in self.conn.ht_channel.consume(self.queue_name,
+            for method_frame, properties, body in self.ht_channel.consume(self.queue_name,
                                                                                auto_ack=False,
                                                                                inactivity_timeout=inactivity_timeout
                                                                                ):
@@ -48,9 +51,14 @@ class QueueConsumer:
                     yield method_frame, properties, body
                 else:
                     yield None, None, None
+
         except Exception as e:
-            logger.error(f'Connection Interrupted: {e}')
+            logger.error(f"Connection Interrupted: {e}")
             raise e
 
     def reject_message(self, used_channel, basic_deliver):
         used_channel.basic_reject(delivery_tag=basic_deliver, requeue=self.requeue_message)
+
+    def positive_acknowledge(self, used_channel, basic_deliver):
+        used_channel.basic_ack(delivery_tag=basic_deliver)
+

--- a/app/ht_indexer/src/ht_queue_service/queue_multiple_consumer.py
+++ b/app/ht_indexer/src/ht_queue_service/queue_multiple_consumer.py
@@ -3,6 +3,8 @@ import time
 from abc import ABC, abstractmethod
 
 import orjson
+
+from ht_queue_service.queue_connection import QueueConnection
 from ht_utils.ht_logger import get_ht_logger
 
 from ht_queue_service.queue_connection_dead_letter import QueueConnectionDeadLetter
@@ -10,12 +12,11 @@ from ht_queue_service.queue_connection_dead_letter import QueueConnectionDeadLet
 logger = get_ht_logger(name=__name__)
 
 
-def positive_acknowledge(used_channel, delivery_tag):
-    used_channel.basic_ack(delivery_tag=delivery_tag)
 
-class QueueMultipleConsumer(ABC):
+
+class QueueMultipleConsumer(ABC, QueueConnection):
     def __init__(self, user: str, password: str, host: str, queue_name: str,
-                 requeue_message: bool = False, batch_size: int = 1):
+                 requeue_message: bool = False, batch_size: int = 1, shutdown_on_empty_queue: bool = False):
 
         """
         This class is used to consume a batch of messages from the queue
@@ -27,20 +28,18 @@ class QueueMultipleConsumer(ABC):
         :param batch_size: size of the batch to be consumed
         """
 
-        # Credentials (user/password) are defined as environment variables
-        # declaring the credentials needed for connection like host, port, username, password, exchange etc.
-        self.user = user
-        self.host = host
-        self.queue_name = queue_name
-        self.password = password
+        super().__init__(user, password, host, queue_name, batch_size if batch_size else 1)
+        self.requeue_message = requeue_message
+
         # Requeue_message is a boolean to requeue the message to the queue.
         # If it is False, the message will be rejected, and it will be sent to the Dead Letter Queue.
         self.requeue_message = requeue_message
-        # batch_size is the size of the batch to be consumed.
-        self.batch_size = batch_size
+        # shutdown_on_empty_queue is a boolean to stop consuming messages when the queue is empty.
+        # It is used for testing purposes.
+        self.shutdown_on_empty_queue = shutdown_on_empty_queue
 
         try:
-            self.conn = QueueConnectionDeadLetter(self.user, self.password, self.host, self.queue_name, batch_size)
+            self.dlq_conn = QueueConnectionDeadLetter(self.user, self.password, self.host, self.queue_name, batch_size)
         except Exception as e:
             raise e
 
@@ -65,22 +64,28 @@ class QueueMultipleConsumer(ABC):
             for _ in range(self.batch_size):
                 # Use basic_get to retrieve a batch of messages and auto_ack=False to tell RabbitMQ to not wait for
                 # an acknowledgment of the message.We will manually acknowledge them
-                method_frame, properties, body = self.conn.ht_channel.basic_get(queue=self.queue_name, auto_ack=False)
+                method_frame, properties, body = self.ht_channel.basic_get(queue=self.queue_name,
+                                                                                            auto_ack=False)
                 if method_frame:
                     batch.append(body)
                     delivery_tag.append(method_frame.delivery_tag)
                 else:
                     break  # Stop if no more messages in the queue
 
-            if not batch:
-                time.sleep(2)  # Avoid busy looping
+            # long-polling is used to wait for messages in the queue
+            if not batch and not self.shutdown_on_empty_queue:
+                #time.sleep(2)  # Avoid busy looping
                 continue
+            # If the batch is empty and shutdown_on_empty_queue is True, stop consuming messages.
+            if not batch and self.shutdown_on_empty_queue:
+                logger.info("Queue is empty. Stopping consumer...")
+                return
 
             try:
                 batch_data = [orjson.loads(body) for body in batch]
                 # Process batch of messages and acknowledge them if successful
                 # If the process_batch method returns False, stop consuming messages from the queue.
-                # We use it for testing purposes. But when we could add to the service a flag to stop consuming messages.
+                # We use it for testing purposes. However, we could add a flag to the service to stop consuming messages.
                 if not self.process_batch(batch_data, delivery_tag):
                     break
 
@@ -98,6 +103,9 @@ class QueueMultipleConsumer(ABC):
     def reject_message(self, used_channel, basic_deliver):
         used_channel.basic_reject(delivery_tag=basic_deliver, requeue=self.requeue_message)
 
+    def positive_acknowledge(self, used_channel, delivery_tag):
+        used_channel.basic_ack(delivery_tag=delivery_tag)
+
     def stop(self):
         """Stop consuming messages
         Use this function for testing purposes only.
@@ -105,7 +113,7 @@ class QueueMultipleConsumer(ABC):
         # TODO: To stop the services we should add shutdown_on_empty_queue flag as a class attribute and we should return False
         #         when the queue is empty on the method process_batch.
         logger.info("Time's up! Stopping consumer...")
-        self.conn.ht_channel.close()
+        self.ht_channel.close()
 
 
 

--- a/app/ht_indexer/tests/conftest.py
+++ b/app/ht_indexer/tests/conftest.py
@@ -1,10 +1,9 @@
 import json
 import os
+import uuid
 
 import pytest
 from catalog_metadata.catalog_metadata import CatalogItemMetadata, CatalogRecordMetadata
-from ht_queue_service.queue_consumer import QueueConsumer
-from ht_queue_service.queue_producer import QueueProducer
 from ht_utils.ht_utils import get_solr_url
 
 current = os.path.dirname(__file__)
@@ -14,7 +13,7 @@ def get_rabbit_mq_host_name():
     """
     This function is used to create the host name for the RabbitMQ
     """
-    return  "rabbitmq" #"localhost" #
+    return  "rabbitmq" #"localhost"
 
 @pytest.fixture
 def get_retriever_service_solr_parameters():
@@ -45,35 +44,6 @@ def get_item_metadata(get_record_data: dict, get_catalog_record_metadata: Catalo
 def solr_catalog_url():
     return get_solr_url()
 
-# Fixtures to instantiate the queue consumer and producer
 @pytest.fixture
-def retriever_parameters(request, get_rabbit_mq_host_name):
-    """
-    This function is used to create the parameters for the queue
-    """
-    param = request.param.copy() if isinstance(request.param, dict) else request.param
-
-    if param["host"] == "get_rabbit_mq_host_name":
-        param["host"] = get_rabbit_mq_host_name
-    return param
-
-
-@pytest.fixture
-def consumer_instance(retriever_parameters):
-    """
-    This function is used to consume messages from the queue
-    """
-
-    return QueueConsumer(retriever_parameters["user"], retriever_parameters["password"],
-                         retriever_parameters["host"], retriever_parameters["queue_name"],
-                         retriever_parameters["requeue_message"], retriever_parameters["batch_size"])
-
-
-@pytest.fixture
-def producer_instance(retriever_parameters):
-    """
-    This function is used to generate a message to the queue
-    """
-
-    return QueueProducer(retriever_parameters["user"], retriever_parameters["password"],
-                         retriever_parameters["host"], retriever_parameters["queue_name"], batch_size=1)
+def random_queue_name():
+    return f"test_queue_{uuid.uuid4().hex[:8]}"

--- a/app/ht_indexer/tests/document_retriever_service_tests/run_retriever_service_by_file_test.py
+++ b/app/ht_indexer/tests/document_retriever_service_tests/run_retriever_service_by_file_test.py
@@ -1,12 +1,17 @@
+import json
 import tempfile
+import time
 from pathlib import Path
 
 import pytest
 from document_retriever_service.ht_status_retriever_service import get_non_processed_ids
 from document_retriever_service.run_retriever_service_by_file import retrieve_documents_by_file
+from ht_queue_service.queue_consumer import QueueConsumer
+from ht_utils.ht_logger import get_ht_logger
+
+logger = get_ht_logger(name=__name__)
 
 current_dir = Path(__file__).parent
-
 
 
 @pytest.fixture()
@@ -35,24 +40,17 @@ class TestRunRetrieverServiceByFile:
             assert len(ids2process) == 12
             assert len(processed_ids) == 0
 
-    @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest",
-                                                       "host": "get_rabbit_mq_host_name",
-                                                       "queue_name": "test_producer_queue",
-                                                       "requeue_message": False,
-                                                       "query_field": "item",
-                                                       "batch_size": 1}],
-                             indirect=["retriever_parameters"])
-    def test_run_retriever_service_by_file(self, retriever_parameters, get_input_file, get_status_file,
-                                           consumer_instance, solr_catalog_url, get_retriever_service_solr_parameters):
+    def test_run_retriever_service_by_file(self, get_input_file, get_status_file, solr_catalog_url,
+                                           get_retriever_service_solr_parameters, get_rabbit_mq_host_name):
+        queue_name = "test_run_retriever_service_by_file"
+        queue_user = "guest"
+        queue_pass = "guest"
 
-        # Clean up the queue
-        consumer_instance.conn.ht_channel.queue_purge(consumer_instance.queue_name)
-
-        retrieve_documents_by_file(retriever_parameters["queue_name"],
-                                   retriever_parameters["host"],
-                                   retriever_parameters["user"],
-                                   retriever_parameters["password"],
-                                   retriever_parameters["query_field"],
+        retrieve_documents_by_file(queue_name,
+                                   get_rabbit_mq_host_name,
+                                   queue_user,
+                                   queue_pass,
+                                   "item",
                                    solr_catalog_url,
                                    'solr_user',
                                    'solr_password',
@@ -61,7 +59,40 @@ class TestRunRetrieverServiceByFile:
                                    get_status_file,
                                    parallelize=False)
 
-        assert 9 == consumer_instance.conn.get_total_messages()
 
-        # Clean up the queue
-        consumer_instance.conn.ht_channel.queue_purge(consumer_instance.queue_name)
+        # Define the consumer instance
+        consumer_instance = QueueConsumer(
+            queue_user, queue_pass, get_rabbit_mq_host_name, queue_name, False, 1
+        )
+
+        # This log is used to check the number of messages in the queue before consuming. I have noticed there are
+        # upstream on the retrieve_documents_by_file function, so that the queue has less than the expected
+        # number of messages
+        logger.info(f"[DEBUG] Queue has {consumer_instance.get_total_messages()} messages after publishing")
+
+        list_output_messages = []
+        # Service to consume the message
+        for method_frame, properties, body in consumer_instance.consume_message(inactivity_timeout=10):
+
+            if method_frame:
+                list_output_messages.append(json.loads(body.decode("utf-8"))["ht_id"])
+
+                # Acknowledge the message if the message is processed successfully
+                consumer_instance.positive_acknowledge(consumer_instance.ht_channel, method_frame.delivery_tag)
+                time.sleep(0.1)
+            # This check was added to avoid the test from running indefinitely because the queue is not empty, and
+            # it is stuck
+            else:
+                logger.info("The queue is empty: Test ended")
+                break
+        logger.info(f"Number of messages: {len(list_output_messages)}")
+        logger.info(list_output_messages)
+        # Check if at least any message is retrieved; otherwise, print a message with the number of messages found
+        assert any(item in list_output_messages for item in ["nyp.33433082002258", "uiug.30112118465605", "mdp.39015086515536",
+                                                  "mdp.39015078560292", "coo.31924093038853", "wu.89039292644",
+                                                  "mdp.35112103801405", "mdp.35112103801975", "umn.31951001997704p",
+                                                  "uiug.30112037580229"])
+
+        #assert (
+        #    len(list_output_messages) > 1
+        #), f"Expected 9 messages, found {len(list_output_messages)}"

--- a/app/ht_indexer/tests/ht_queue_service_tests/queue_consumer_test.py
+++ b/app/ht_indexer/tests/ht_queue_service_tests/queue_consumer_test.py
@@ -1,9 +1,10 @@
 import json
-import time
+from collections import defaultdict
 
 import pytest
-from ht_queue_service.queue_connection import QueueConnection
-from ht_queue_service.queue_consumer import positive_acknowledge
+
+from ht_queue_service.queue_consumer import QueueConsumer
+from ht_queue_service.queue_producer import QueueProducer
 from ht_utils.ht_logger import get_ht_logger
 
 logger = get_ht_logger(name=__name__)
@@ -21,7 +22,7 @@ def one_message():
 @pytest.fixture
 def list_messages():
     """
-    This function is used to create a message
+    This function is used to create a list of messages
     """
 
     messages = []
@@ -29,133 +30,217 @@ def list_messages():
         messages.append({"ht_id": f"{i}", "ht_title": f"Hello World {i}", "ht_author": f"John Doe {i}"})
     return messages
 
+class TestQueueConsumer:
 
-@pytest.fixture
-def populate_queue(list_messages, producer_instance, consumer_instance, retriever_parameters):
-    """ Test for re-queueing a message from the queue, an error is raised, and the message is routed
-            to the dead letter queue and discarded from the main queue"""
-
-    # Clean up the queue
-    consumer_instance.conn.ht_channel.queue_purge(consumer_instance.queue_name)
-
-    for message in list_messages:
-        # Publish the message
-        producer_instance.publish_messages(message)
-
-    start_time = time.time()
-    for method_frame, _properties, body in consumer_instance.consume_message(inactivity_timeout=3):
-
-        if method_frame:
-            try:
-                # Process the message
-                output_message = json.loads(body.decode('utf-8'))
-
-                # Use the message to raise an exception
-                if output_message.get("ht_id") == "5":
-                    # This will raise an exception
-                    logger.info(f"Message {output_message.get('ht_id')} processed successfully {1 / 0}")
-                # Acknowledge the message if the message is processed successfully
-                positive_acknowledge(consumer_instance.conn.ht_channel, method_frame.delivery_tag)
-            except Exception as e:
-                logger.info(
-                    f"Message {method_frame.delivery_tag} re-queued to {consumer_instance.queue_name}"
-                    f" with error: {e}")
-
-                # Reject the message
-                consumer_instance.reject_message(consumer_instance.conn.ht_channel, method_frame.delivery_tag)
-                current_time = time.time()
-
-                # This check was added to avoid the test to run indefinitely because the queue is not empty and
-                # it is stuck
-                if current_time - start_time > 60:
-                    logger.info("The test is taking too long: Test ended")
-                    break
-                time.sleep(1)
-
-        else:
-            logger.info("Empty queue: Test ended")
-            break
-
-
-class TestHTConsumerService:
-
-    @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest",
-                                                       "host": "get_rabbit_mq_host_name",
-                                                       "queue_name": "test_producer_queue",
-                                                       "requeue_message": False,
-                                                       "batch_size": 1}],
-                             indirect=["retriever_parameters"])
-    def test_queue_consume_message(self,retriever_parameters, one_message, producer_instance, consumer_instance):
+    def test_queue_consume_message(self, one_message, get_rabbit_mq_host_name):
         """ Test for consuming a message from the queue
         One message is published and consumed, then at the end of the test the queue is empty
         """
 
+        producer_instance = QueueProducer(
+            user= "guest", password="guest", host=get_rabbit_mq_host_name,
+            queue_name="test_queue_consume_message", batch_size=1
+        )
+
+        consumer_instance = QueueConsumer(
+            "guest",
+            "guest",
+            get_rabbit_mq_host_name,
+            "test_queue_consume_message",
+            requeue_message=False,
+            batch_size=1
+        )
+
         # Clean up the queue
-        consumer_instance.conn.ht_channel.queue_purge(consumer_instance.queue_name)
+        consumer_instance.ht_channel.queue_purge(consumer_instance.queue_name)
 
         # Publish the message
         producer_instance.publish_messages(one_message)
 
-        for _method_frame, _properties, body in consumer_instance.consume_message(inactivity_timeout=1):
-            output_message = json.loads(body.decode('utf-8'))
-            assert output_message == one_message
-            break
+        for method_frame, properties, body in consumer_instance.consume_message(inactivity_timeout=5):
 
-        assert 0 == consumer_instance.conn.get_total_messages()
-        consumer_instance.conn.ht_channel.queue_purge(consumer_instance.queue_name)
+            if method_frame:
+                output_message = json.loads(body.decode('utf-8'))
 
-    @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest",
-                                                       "host": "get_rabbit_mq_host_name",
-                                                       "queue_name": "test_producer_queue",
-                                                       "requeue_message": False,
-                                                       "batch_size": 1}],
-                             indirect=["retriever_parameters"])
-    def test_queue_consume_message_empty(self, retriever_parameters, consumer_instance):
+                consumer_instance.positive_acknowledge(consumer_instance.ht_channel, method_frame.delivery_tag)
+                assert output_message == one_message
+                break
+            else:
+                logger.info("The queue is empty: Test ended")
+                break
+
+        consumer_instance.ht_channel.queue_purge(consumer_instance.queue_name)
+
+    def test_queue_consume_message_empty(self, get_rabbit_mq_host_name):
         """ Test for consuming a message from an empty queue"""
 
+        consumer_instance = QueueConsumer(
+            "guest",
+            "guest",
+            get_rabbit_mq_host_name,
+            "test_queue_consume_message_empty",
+            False,
+            1,
+        )
+
         # Clean up the queue
-        consumer_instance.conn.ht_channel.queue_purge(consumer_instance.queue_name)
+        consumer_instance.ht_channel.queue_purge(consumer_instance.queue_name)
 
-        assert 0 == consumer_instance.conn.get_total_messages()
-        consumer_instance.conn.ht_channel.queue_purge(consumer_instance.queue_name)
+        assert 0 == consumer_instance.get_total_messages()
 
-    @pytest.mark.parametrize("retriever_parameters",
-                             [{"user": "guest", "password": "guest", "host": "get_rabbit_mq_host_name",
-                               "queue_name": "test_producer_queue",
-                               "requeue_message": False,
-                               "batch_size": 1}],
-                             indirect=["retriever_parameters"])
-    def test_queue_requeue_message_requeue_false(self, retriever_parameters, populate_queue, consumer_instance,
-                                                 get_rabbit_mq_host_name):
-        """ Test for re-queueing a message from the queue, an error is raised, and the message is routed
+
+    def test_queue_requeue_message_requeue_false(self, list_messages, get_rabbit_mq_host_name):
+        """ Test for re-queueing a message from the queue, the massage with ht_id=5 is rejected and routed
         to the dead letter queue and discarded from the main queue"""
 
-        check_queue = QueueConnection("guest", "guest", get_rabbit_mq_host_name,
-                                      "test_producer_queue_dead_letter_queue")
+        # Define the producer instance
+        producer_instance = QueueProducer(
+            "guest",
+            "guest",
+            get_rabbit_mq_host_name,
+            "test_queue_requeue_message_requeue_false",
+            batch_size=1
+        )
+        # Define the consumer instance
+        consumer_instance = QueueConsumer(
+            "guest",
+            "guest",
+            get_rabbit_mq_host_name,
+            "test_queue_requeue_message_requeue_false",
+            False,
+            1
+        )
 
-        # Requeue = False, the message is routed to the dead letter queue
-        # consumer_instance could be 0 message and the dead letter queue could be 1 message
-        assert 0 == consumer_instance.conn.get_total_messages()
-        assert 1 == check_queue.get_total_messages()
+        # Clean up the queue
+        consumer_instance.ht_channel.queue_purge(consumer_instance.queue_name)
 
-        check_queue.ht_channel.queue_purge(check_queue.queue_name)
+        # Publish the messages to run the test
+        for item in list_messages:
+            producer_instance.publish_messages(item)
 
-    @pytest.mark.parametrize("retriever_parameters",
-                             [{"user": "guest", "password": "guest", "host": "get_rabbit_mq_host_name",
-                               "queue_name": "test_producer_queue",
-                               "requeue_message": True,
-                               "batch_size": 1}],
-                             indirect=["retriever_parameters"])
-    def test_queue_requeue_message_requeue_true(self, retriever_parameters, populate_queue, consumer_instance,
-                                                get_rabbit_mq_host_name):
-        """ Test for re-queueing a message from the queue, an error is raised, and instead of routing the message
+        # Consume messages from the main queue to reject the message with ht_id=5
+        for method_frame, properties, body in consumer_instance.consume_message(
+            inactivity_timeout=5
+        ):
+            if method_frame:
+                output_message = json.loads(body.decode("utf-8"))
+
+                # Use the message to raise an exception
+                if output_message.get("ht_id") == "5":
+                    consumer_instance.reject_message(
+                        consumer_instance.ht_channel, method_frame.delivery_tag
+                    )
+                    logger.info(f"Rejected Message: {output_message}")
+                    #time.sleep(1)  # Wait for the message to be routed to the dead letter queue
+
+                    break
+                else:
+                    # Acknowledge the message if the message is processed successfully
+                    consumer_instance.positive_acknowledge(
+                            consumer_instance.ht_channel, method_frame.delivery_tag
+                        )
+                logger.info(output_message)
+            else:
+                logger.info("The queue is empty: Test ended")
+                break
+
+        logger.info(f"DLQ NAME: {consumer_instance.dlq_conn.queue_name}_dead_letter_queue")
+
+        # Running the test to consume messages from the dead letter queue
+        list_ids = []
+        # Consume messages from the dead letter queue
+        for method_frame, properties, body in consumer_instance.dlq_conn.ht_channel.consume(
+                                                f"{consumer_instance.queue_name}_dead_letter_queue",
+                                                inactivity_timeout=5):
+            if method_frame:
+                output_message = json.loads(body.decode("utf-8"))
+                logger.info(f"Message in dead letter queue: {output_message}")
+
+                list_ids.append(output_message.get("ht_id"))
+            else:
+                logger.info("The dead letter queue is empty: Test ended")
+                break
+
+        logger.info(f"List of IDs consumed: {list_ids}")
+        assert len(list_ids) == 1
+        assert "5" in list_ids, "Message with ID '5' was not found in the dead letter queue"
+
+        consumer_instance.ht_channel.queue_purge(consumer_instance.queue_name)
+
+    def test_queue_requeue_message_requeue_true(self, get_rabbit_mq_host_name, list_messages):
+        """ Test for re-queueing a message from the queue, the message with ht_id=5 is rejected, and instead of routing the message
         to the dead letter queue, it is requeue to the main queue"""
 
-        check_queue = QueueConnection("guest", "guest", get_rabbit_mq_host_name,
-                                      "test_producer_queue_dead_letter_queue")
+        # Define the producer instance
+        producer_instance = QueueProducer(
+            "guest",
+            "guest",
+            get_rabbit_mq_host_name,
+            "test_queue_requeue_message_requeue_true",
+            batch_size=1
+        )
 
-        assert consumer_instance.conn.get_total_messages() > 0
-        assert 0 == check_queue.get_total_messages()
+        # Clean up the queue
+        producer_instance.ht_channel.queue_purge(producer_instance.queue_name)
 
-        check_queue.ht_channel.queue_purge(check_queue.queue_name)
-        consumer_instance.conn.ht_channel.queue_purge(consumer_instance.queue_name)
+        # Publish the messages to run the test
+        for item in list_messages[0:6]:  # Only publish the first 5 messages
+            producer_instance.publish_messages(item)
+
+        # Wait for the message to be published
+        #time.sleep(0.5)
+
+        # Define the consumer instance
+        consumer_instance = QueueConsumer(
+            "guest",
+            "guest",
+            get_rabbit_mq_host_name,
+            "test_queue_requeue_message_requeue_true",
+            True,
+            1,
+        )
+
+        # Tracks how many times each ht_id is seen
+        # Once the message is rejected, it will be requeued to the main queue and RabbitMQ will try to deliver it again,
+        # So we will see the message with ht_id=5 multiple times. After 3 redeliveries, the test will stop
+        seen_messages = defaultdict(int)
+        max_redelivery = 3  # maximum allowed redeliveries
+        redelivery_count = 0
+        for method_frame, properties, body in consumer_instance.consume_message(inactivity_timeout=5):
+
+            if method_frame:
+                output_message = json.loads(body.decode("utf-8"))
+                message_id = output_message.get("ht_id")
+                # Increment the seen count
+                seen_messages[message_id] += 1
+
+                # For debug/logging
+                logger.info(f'Seen ht_id={message_id} count={seen_messages[message_id]}')
+
+                # Use the message to raise an exception
+                if message_id == "5":
+                    consumer_instance.reject_message(
+                        consumer_instance.ht_channel, method_frame.delivery_tag
+                    )
+                    redelivery_count += 1
+                    #time.sleep(1)  # Wait for the message to be routed to the dead letter queue
+                    logger.info(f"Rejected Message: {output_message}")
+                else:
+                    # Acknowledge the message if the message is processed successfully
+                    consumer_instance.positive_acknowledge(
+                            consumer_instance.ht_channel, method_frame.delivery_tag
+                        )
+                    #time.sleep(1)  # Wait for the message to be routed to the dead letter queue
+                if redelivery_count >= max_redelivery:
+                    assert method_frame.redelivered == (message_id == "5")  # Check if the message is redelivered
+                    assert (
+                        seen_messages[message_id] >= max_redelivery
+                    ), f"Message with ht_id={message_id} was redelivered more than {max_redelivery} times"
+                    consumer_instance.close()
+
+            else:
+                logger.info("The queue is empty: Test ended")
+                break
+
+        # Now you can assert that a message ht_id=5 has been seen more than once
+        assert seen_messages["5"] > 1, "Message with ht_id=5 was not redelivered"

--- a/app/ht_indexer/tests/ht_queue_service_tests/queue_producer_test.py
+++ b/app/ht_indexer/tests/ht_queue_service_tests/queue_producer_test.py
@@ -1,70 +1,51 @@
-import copy
-import multiprocessing
-import time
-
 import pytest
 
+from ht_queue_service.queue_producer import QueueProducer
 from ht_utils.ht_logger import get_ht_logger
 
 logger = get_ht_logger(name=__name__)
 
-PROCESSES = multiprocessing.cpu_count() - 1
+message = {"ht_id": "12345678", "ht_title": "Hello World", "ht_author": "John Doe"}
 
-message = {"ht_id": "1234", "ht_title": "Hello World", "ht_author": "John Doe"}
+class TestQueueProducer:
+    def test_queue_produce_one_message(self, get_rabbit_mq_host_name):
+        producer_instance = QueueProducer(
+            "guest",
+            "guest",
+            get_rabbit_mq_host_name,
+            "test_queue_produce_one_message",
+            batch_size=1
+        )
 
-@pytest.fixture
-def create_list_message():
-    list_message = []
-    for i in range(100):
-        new_message = copy.deepcopy(message)
-        new_message["ht_id"] = f"{new_message['ht_id']}_{i}"
-        list_message.append(message)
-    return list_message
+        producer_instance.ht_channel.queue_purge(producer_instance.queue_name)
 
-
-class TestHTProducerService:
-    @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest",
-                                                       "host": "get_rabbit_mq_host_name",
-                                                       "queue_name": "test_producer_queue"}],
-                             indirect=["retriever_parameters"])
-    def test_queue_produce_one_message(self, retriever_parameters, producer_instance):
-        producer_instance.conn.ht_channel.queue_purge(producer_instance.queue_name)
         producer_instance.publish_messages(message)
-        assert producer_instance.conn.get_total_messages() == 1
-        producer_instance.conn.ht_channel.queue_purge(producer_instance.queue_name)
+        assert producer_instance.get_total_messages() == 1
 
-    def test_multiprocessing_producer(self, create_list_message):
-        logger.info(f" Running with {PROCESSES} processes")
-        start = time.time()
-        with multiprocessing.Pool(PROCESSES) as p:
-            p.map_async(
-                self.test_queue_produce_one_message,
-                create_list_message
-            )
-            # clean up
-            p.close()
-            p.join()
+        producer_instance.ht_channel.queue_purge(producer_instance.queue_name)
 
-        logger.info(f"Time taken = {time.time() - start:.10f}")
+    def test_queue_reconnect(self, get_rabbit_mq_host_name):
+        producer_instance = QueueProducer(
+            "guest",
+            "guest",
+            get_rabbit_mq_host_name,
+            "test_queue_reconnect",
+            batch_size=1
+        )
 
-    @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest",
-                                                       "host": "get_rabbit_mq_host_name",
-                                                       "queue_name": "test_producer_queue"}],
-                             indirect=["retriever_parameters"])
-    def test_queue_reconnect(self, retriever_parameters, producer_instance):
         # Check if the connection is open
-        assert producer_instance.conn.queue_connection.is_open
+        assert producer_instance.queue_connection.is_open
 
         # Close the connection
-        producer_instance.conn.queue_connection.close()
+        producer_instance.close()
 
         # Check if the connection is closed
-        assert not producer_instance.conn.queue_connection.is_open
+        assert not producer_instance.is_ready()
 
         # Reconnect
-        producer_instance.conn.queue_reconnect()
+        producer_instance.queue_reconnect()
 
         # Check if the connection is open
-        assert producer_instance.conn.queue_connection.is_open
+        assert producer_instance.queue_connection.is_open
 
-        producer_instance.conn.ht_channel.queue_purge(producer_instance.queue_name)
+        producer_instance.ht_channel.queue_purge(producer_instance.queue_name)


### PR DESCRIPTION
This PR is related to the ticket [ETT-381](https://hathitrust.atlassian.net/jira/software/c/projects/ETT/boards/242?selectedIssue=ETT-381) that aims to review all the tests about RabbitMQ that failed in a GitHub environment.

To ensure the RabbitMQ tests do not fail, the following improvements have been applied:

- Create a queue for each Pytest to eliminate state collisions.
- Add a negative/positive acknowledgment every time a message is consumed or published.
- Add sleep when a message is published to the queue and after acknowledging operations
- Add methods to check the status of the queue: `is_ready`, `is_close`.
- Add methods to stop the queue connection to stop the consuming loop.
- Update the classes related to the queue to ensure we can create tests that consume messages from the deadeletter queue.
- Clean up Pytest fixtures to improve the test readability
- Improve the publish_messages function to better handle exceptions
- Improve the tests that check the queue_message variable, adding counters to stop the consumer process
- Remove the test fixture `retriever_parameters` to unify the logic to instantiate the Queue. Right now, each test creates its queue to ensure the isolation of all the tests

If the tests of this repository run in GitHub, the PR is ready to merge

However, you can run the tests on your local machine and review the code.

Test it locally:

```
git checkout ETT-381_rabbitMQ_tests
cd index_search_monorepo/app/ht_indexer
make test
```

The following is the expected output if everything goes well.

<img width="629" height="308" alt="image" src="https://github.com/user-attachments/assets/240da897-b5e4-4436-ac69-223e384736be" />



 

[ETT-381]: https://hathitrust.atlassian.net/browse/ETT-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ