### PR TITLE
Syntax error in queue_producer + connection error in document_generat…

### DIFF
--- a/app/ht_indexer/src/document_generator/generator_arguments.py
+++ b/app/ht_indexer/src/document_generator/generator_arguments.py
@@ -91,8 +91,8 @@ class GeneratorServiceArguments:
             sys.exit(1)
 
         try:
-            src_queue_config = QueueConfig(global_config, app_config, config_key="src_queue")
-            tgt_queue_config = QueueConfig(global_config, app_config, config_key="tgt_queue")
+            src_queue_config = QueueConfig(global_config, app_config, config_key="src_queue", prefix="SRC_")
+            tgt_queue_config = QueueConfig(global_config, app_config, config_key="tgt_queue", prefix="TGT_")
             return src_queue_config, tgt_queue_config
         except KeyError as e:
             logger.error(

--- a/app/ht_indexer/src/document_retriever_service/full_text_search_retriever_service.py
+++ b/app/ht_indexer/src/document_retriever_service/full_text_search_retriever_service.py
@@ -45,6 +45,13 @@ FAILURE_UPDATE_STATUS = f"UPDATE {PROCESSING_STATUS_TABLE_NAME} SET status = :st
 SOLR_BATCH_SIZE = 200 # The chunk size is 200, because Solr will fail with the status code 414. The chunk size was determined
 # by testing the Solr query with different values (e.g., 100-500 and with 200 ht_ids it worked.
 
+# TODO: Apply the Strategy Pattern on this module to encapsulate the logic of extracting the documents by ht_id or
+#  record_id, it will reduce the if-else statements in the code
+SOLR_ID_EXTRACTION_STRATEGIES = {
+    "item": RetrieverServicesUtils.extract_hathitrust_ids,
+    "record": RetrieverServicesUtils.extract_catalog_record_id,
+}
+
 class FullTextSearchRetrieverQueueService:
     """
     This class is responsible to retrieve the documents from the Catalog and generate the full text search entry
@@ -327,10 +334,12 @@ def main():
     if len(init_args_obj.list_documents) > 0:
 
         # If the list of documents is provided, the process will run only for the documents in the list
-        list_ids = RetrieverServicesUtils.extract_ids_from_documents(init_args_obj.list_documents, by_field)
-        logger.info(f"Process=retrieving: Total of documents to process {len(list_ids)}")
+        #list_ids = RetrieverServicesUtils.extract_ids_from_documents(init_args_obj.list_documents, by_field)
+        logger.info(f"Process=retrieving: Total of documents to process {len(init_args_obj.list_documents)}")
 
-        document_retriever_service.full_text_search_retriever_service(init_args_obj.db_conn, list_ids, by_field)
+        document_retriever_service.full_text_search_retriever_service(init_args_obj.db_conn,
+                                                                      init_args_obj.list_documents,
+                                                                      by_field)
     else:
 
         # If the table does not exist, stop the process
@@ -349,8 +358,12 @@ def main():
                 time.sleep(WAITING_TIME_MYSQL)
                 continue
             else:
-                list_ids = RetrieverServicesUtils.extract_ids_from_documents(list_documents, by_field)
 
+                extract_ids = SOLR_ID_EXTRACTION_STRATEGIES.get(by_field)
+                if extract_ids is None:
+                    logger.error(f"Error: by_field {by_field} not supported")
+                    sys.exit(1)
+                list_ids = extract_ids(list_documents)
             logger.info(f"Process=retrieving: Total of documents to process {len(list_ids)}")
 
             if init_args_obj.parallelize:

--- a/app/ht_indexer/src/document_retriever_service/retriever_services_utils.py
+++ b/app/ht_indexer/src/document_retriever_service/retriever_services_utils.py
@@ -1,4 +1,5 @@
 import json
+from typing import List
 
 from catalog_metadata.catalog_metadata import CatalogItemMetadata, CatalogRecordMetadata
 from ht_queue_service.queue_producer import QueueProducer
@@ -32,19 +33,26 @@ class RetrieverServicesUtils:
         return catalog_item_metadata
 
     @staticmethod
-    def extract_ids_from_documents(list_documents, by_field):
+    def extract_hathitrust_ids(list_documents: List[dict]) -> list[str]:
         """
         Prepare the list of ids to be processed
-        :param list_documents: list of documents to process
-        :param by_field: field to search by (item=ht_id or record=id)
+        :param list_documents: list of records
         :return: list of ids to be processed
         """
 
-        if by_field == 'record':
-            list_documents = [record['record_id'] for record in list_documents]
+        list_documents = [record["ht_id"] for record in list_documents]
 
-        if by_field == 'item':
-            list_documents = [record['ht_id'] for record in list_documents]
+        return list_documents
+
+    @staticmethod
+    def extract_catalog_record_id(list_documents: List[dict]) -> list[str]:
+        """
+        Prepare the list of ids to be processed
+        :param list_documents: list of records
+        :return: list of ids to be processed
+        """
+
+        list_documents = [record["record_id"] for record in list_documents]
 
         return list_documents
 

--- a/app/ht_indexer/src/ht_queue_service/queue_config.py
+++ b/app/ht_indexer/src/ht_queue_service/queue_config.py
@@ -38,22 +38,33 @@ def _load_config(config_path: Path) -> dict[str, Any]:
 
 class QueueConfig:
 
-    ENV_MAPPING = {
-        "host": "QUEUE_HOST",
-        "port": "QUEUE_PORT",
-        "user": "QUEUE_USER",
-        "password": "QUEUE_PASS",
-        "queue_name": "QUEUE_NAME"
-    }
-
-    def __init__(self, global_path: Path, app_path: Path, config_key: str="queue") -> None:
+    def __init__(self, global_path: Path, app_path: Path, config_key: str="queue", prefix:str="") -> None:
         """
         Initialize the QueueConfig with default values or load from a YAML file.
 
         :param global_path: Path to the global YAML configuration file.
         :param app_path: Path to the application-specific YAML configuration file.
         :param config_key: Key to identify the specific queue configuration in the YAML files.
+        :param prefix: Optional prefix for environment variables to initialize the queue configuration
+        for document_generator service that has a source (_SRC) and target (_TGT) queues.
         """
+
+        self.env_mapping = {
+            "host": "QUEUE_HOST",
+            "port": "QUEUE_PORT",
+            "user": "QUEUE_USER",
+            "password": "QUEUE_PASS",
+            "queue_name": "QUEUE_NAME"
+        }
+
+        if prefix:
+            self.env_mapping = {
+            "host": f"{prefix}QUEUE_HOST",
+            "port": f"{prefix}QUEUE_PORT",
+            "user": f"{prefix}QUEUE_USER",
+            "password": f"{prefix}QUEUE_PASS",
+            "queue_name": f"{prefix}QUEUE_NAME"
+        }
 
         default_global_config = _load_config(global_path)["queue"]
 
@@ -82,7 +93,7 @@ class QueueConfig:
 
         # Override with environment variables if they exist
         # Environment variables take precedence over config file values
-        for key, env_var in self.ENV_MAPPING.items():
+        for key, env_var in self.env_mapping.items():
             env_value = os.getenv(env_var)
             if env_value is not None:
                 if key == "port":  # cast port to int if overridden

--- a/app/ht_indexer/src/ht_queue_service/queue_producer.py
+++ b/app/ht_indexer/src/ht_queue_service/queue_producer.py
@@ -25,7 +25,7 @@ class QueueProducer:
       and ready via `QueueManager`.
     - Uses a thread-local channel for each non-main thread to avoid sharing non-thread-safe
       Pika channels across threads.
-    - Makes published messages persistent (delivery mode \= 2) and JSON-encodes payloads.
+    - Makes published messages persistent (delivery mode = 2) and JSON-encodes payloads.
     - Detects closed channels/connections, reconnects, and retries the publish once.
 
     Attributes:

--- a/app/ht_indexer/tests/document_retriever_service_tests/retriever_services_utils_test.py
+++ b/app/ht_indexer/tests/document_retriever_service_tests/retriever_services_utils_test.py
@@ -15,3 +15,26 @@ class TestRetrieverServicesUtils:
         assert len(results) == 1
         assert results[0].ht_id == "mdp.39015078560292"
         assert results[0].metadata.get("vol_id") == "mdp.39015078560292"
+
+    def test_extract_hathitrust_ids(self):
+        docs = [
+            {"ht_id": 101, "record_id": "A"},
+            {"ht_id": 202, "record_id": "B"},
+            {"ht_id": 303, "record_id": "C"},
+        ]
+        result = RetrieverServicesUtils.extract_hathitrust_ids(docs)
+        assert result == [101, 202, 303]
+        # Empty list
+        assert RetrieverServicesUtils.extract_hathitrust_ids([]) == []
+
+    def test_extract_catalog_record_id(self):
+        docs = [
+            {"ht_id": 101, "record_id": "A"},
+            {"ht_id": 202, "record_id": "B"},
+            {"ht_id": 303, "record_id": "C"},
+        ]
+        result = RetrieverServicesUtils.extract_catalog_record_id(docs)
+        assert  result == ["A", "B", "C"]
+
+        # Empty list
+        assert RetrieverServicesUtils.extract_catalog_record_id([]) == []


### PR DESCRIPTION
This PR is to solve different problems running the services in Kubernetes
- Syntax error in queue_producer class
- Using Strategy pattern to create the list of documents to process according with the parameter ht_id or record_id
- Fix the QueueConfig class to enable different names of the queue parameters, such as QUEUE_USER or SRC_QUEUE_USER