### PR TITLE
ETT-1763 Fix four correctness bugs

### DIFF
--- a/app/data_operations/src/kbart_file_generator/kbart_file_generator.py
+++ b/app/data_operations/src/kbart_file_generator/kbart_file_generator.py
@@ -207,7 +207,7 @@ def fetch_title_dates_from_mysql_batch(
     for row in db_conn.query_mysql(query, params=params):
         bib_num = first_value(row.get("bib_num"))
         if bib_num:
-            results_by_id[bib_num] = row
+            results_by_id[normalize_catalog_id_stripped_zeros(bib_num)] = row
 
     return results_by_id
 
@@ -336,12 +336,13 @@ def generate_kbart_rows(
     errors: list[dict[str, str]] = []
 
     for catalog_id in catalog_ids:
-        metadata = metadata_by_id.get(catalog_id)
+        normalized_id = normalize_catalog_id_stripped_zeros(catalog_id)
+        metadata = metadata_by_id.get(normalized_id)
         if metadata is None:
             errors.append({"catalog_id": catalog_id, "reason": "metadata not found"})
             continue
 
-        row = build_kbart_row(metadata, date_by_id.get(catalog_id))
+        row = build_kbart_row(metadata, date_by_id.get(normalized_id))
         if not row["publication_title"] or not row["title_id"]:
             errors.append({"catalog_id": catalog_id, "reason": "required source fields missing"})
             continue

--- a/app/data_operations/tests/test_kbart_file_generator.py
+++ b/app/data_operations/tests/test_kbart_file_generator.py
@@ -1,11 +1,13 @@
 import csv
 from pathlib import Path
 
+import kbart_file_generator.kbart_file_generator as kbart_module
 import pytest
 from kbart_file_generator.kbart_file_generator import (
     KBART_COLUMN_ORDER,
     build_kbart_row,
     fetch_title_dates_from_mysql_batch,
+    generate_kbart_rows,
     read_catalog_ids,
 )
 
@@ -114,3 +116,43 @@ def test_fetch_title_dates_from_mysql_batch_queries_one_batch(
             "date_last_issue_online": "2005",
         },
     }
+
+
+def test_generate_kbart_rows_matches_zero_padded_ids_to_stripped_lookup_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lookup results are keyed by catalog id with leading zeros stripped; catalog_ids from
+    the input file are zero-padded."""
+
+    def fake_fetch_lookup_results_in_parallel(catalog_ids, batch_size=None):
+        return (
+            {
+                "9040": {
+                    "id": "0009040",
+                    "title_display": "Gerodontology",
+                    "isbn": ["07340664"],
+                    "mainauthor": "Beech Hill Enterprises",
+                    "publisher": ["Beech Hill Enterprises,"],
+                    "oclc": ["8731707"],
+                },
+            },
+            {
+                "9040": {
+                    "date_first_issue_online": "2001",
+                    "date_last_issue_online": "2005",
+                    "bib_fmt": "SE",
+                },
+            },
+        )
+
+    monkeypatch.setattr(
+        kbart_module, "fetch_lookup_results_in_parallel", fake_fetch_lookup_results_in_parallel
+    )
+
+    rows, errors = generate_kbart_rows(["0009040"])
+
+    assert errors == []
+    assert len(rows) == 1
+    assert rows[0]["title_id"] == "9040"
+    assert rows[0]["publication_title"] == "Gerodontology"
+    assert rows[0]["date_first_issue_online"] == "2001"

--- a/app/ht_indexer/src/document_retriever_service/full_text_search_retriever_service.py
+++ b/app/ht_indexer/src/document_retriever_service/full_text_search_retriever_service.py
@@ -348,8 +348,6 @@ def main():
         # The process will run every 5 minutes to check if there are documents to process (retriever_status = pending)
         while True:
             total_time_waiting = 0
-            if total_time_waiting > 0:
-                logger.info(f"Process=retrieving: Waiting {total_time_waiting} until reduce the number of messages in the queue")
             list_documents = init_args_obj.db_conn.query_mysql(init_args_obj.retriever_query, params={"status": "pending"})
             if len(list_documents) == 0:
                 logger.info("No documents to process")
@@ -378,7 +376,7 @@ def main():
 
                 document_retriever_service.full_text_search_retriever_service(
                     init_args_obj.db_conn,
-                    list_documents,
+                    list_ids,
                     by_field
                 )
 

--- a/app/ht_indexer/tests/document_retriever_service_tests/full_text_search_retriever_service_test.py
+++ b/app/ht_indexer/tests/document_retriever_service_tests/full_text_search_retriever_service_test.py
@@ -1,10 +1,11 @@
 import json
 import os
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from conftest import create_test_queue_config
+from document_retriever_service import full_text_search_retriever_service as retriever_service_module
 from document_retriever_service.full_text_search_retriever_service import (
     FullTextSearchRetrieverQueueService,
 )
@@ -258,4 +259,39 @@ class TestFullTextRetrieverService:
             response = FullTextSearchRetrieverQueueService.retrieve_documents_from_solr(query,
                                                                                     get_catalog_retriever_service_solr_fake_solr_url)
             assert response is None
+
+
+class _StopPollLoop(Exception):
+    """Raised to break out of main()'s `while True` once the call under test has happened."""
+
+
+class TestMainSerialBranch:
+    """main()'s polling loop passes MySQL rows straight to the single-thread branch instead of
+    the extracted id strings the parallel branch uses. make_solr_term_query() joins its input
+    with a comma, so a list of dicts blows up with a TypeError."""
+
+    def test_serial_branch_passes_extracted_ids_not_raw_mysql_rows(self):
+        mock_args = MagicMock()
+        mock_args.list_documents = []
+        mock_args.query_field = "item"
+        mock_args.parallelize = False
+        mock_args.db_conn.table_exists.return_value = True
+        mock_args.db_conn.query_mysql.return_value = [
+            {"ht_id": "nyp.001", "record_id": "1"},
+            {"ht_id": "nyp.002", "record_id": "2"},
+        ]
+
+        mock_service_instance = MagicMock()
+        mock_service_instance.get_queue_producer.side_effect = _StopPollLoop
+
+        with patch.object(retriever_service_module, "RetrieverServiceArguments", return_value=mock_args), \
+                patch.object(retriever_service_module, "FullTextSearchRetrieverQueueService",
+                              return_value=mock_service_instance), \
+                pytest.raises(_StopPollLoop):
+            retriever_service_module.main()
+
+        mock_service_instance.full_text_search_retriever_service.assert_called_once()
+        _, documents_arg, by_field_arg = mock_service_instance.full_text_search_retriever_service.call_args.args
+        assert documents_arg == ["nyp.001", "nyp.002"]
+        assert by_field_arg == "item"
 

--- a/app/ht_indexer/tests/document_retriever_service_tests/full_text_search_retriever_service_test.py
+++ b/app/ht_indexer/tests/document_retriever_service_tests/full_text_search_retriever_service_test.py
@@ -5,7 +5,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from conftest import create_test_queue_config
-from document_retriever_service import full_text_search_retriever_service as retriever_service_module
+from document_retriever_service import (
+    full_text_search_retriever_service as retriever_service_module,
+)
 from document_retriever_service.full_text_search_retriever_service import (
     FullTextSearchRetrieverQueueService,
 )
@@ -261,7 +263,7 @@ class TestFullTextRetrieverService:
             assert response is None
 
 
-class _StopPollLoop(Exception):
+class _StopPollLoopError(Exception):
     """Raised to break out of main()'s `while True` once the call under test has happened."""
 
 
@@ -282,12 +284,12 @@ class TestMainSerialBranch:
         ]
 
         mock_service_instance = MagicMock()
-        mock_service_instance.get_queue_producer.side_effect = _StopPollLoop
+        mock_service_instance.get_queue_producer.side_effect = _StopPollLoopError
 
         with patch.object(retriever_service_module, "RetrieverServiceArguments", return_value=mock_args), \
                 patch.object(retriever_service_module, "FullTextSearchRetrieverQueueService",
                               return_value=mock_service_instance), \
-                pytest.raises(_StopPollLoop):
+                pytest.raises(_StopPollLoopError):
             retriever_service_module.main()
 
         mock_service_instance.full_text_search_retriever_service.assert_called_once()

--- a/app/solr_query/src/ht_full_text_search/ht_full_text_searcher.py
+++ b/app/solr_query/src/ht_full_text_search/ht_full_text_searcher.py
@@ -68,18 +68,19 @@ class HTFullTextSearcher(HTSearcher):
         :return:
         """
 
-        # Processing long queries
-        if len(list_ids) > 100:
-            # processing the query in batches
-            while list_ids:
-                chunk, list_ids = list_ids[:100], list_ids[100:]
+        if not list_ids:
+            return
 
-                list_docs, list_debug = self.solr_result_output(q_string=q_string, fl=fl, operator=operator, filter_dict={"id": chunk},
-                    q_filter=q_filter
-                )
-                logger.info(f"One batch of results {len(chunk)}")
+        # Processing the query in batches of 100 ids per Solr query
+        while list_ids:
+            chunk, list_ids = list_ids[:100], list_ids[100:]
 
-                yield list_docs, list_debug
+            list_docs, list_debug = self.solr_result_output(q_string=q_string, fl=fl, operator=operator, filter_dict={"id": chunk},
+                q_filter=q_filter
+            )
+            logger.info(f"One batch of results {len(chunk)}")
+
+            yield list_docs, list_debug
 
         # TODO implement the of AB test and interleave, Check the logic in the LS::Operation::Search.
         #  In previous versions of this repository you will find the logic to implement this feature (perl code

--- a/app/solr_query/tests/ht_full_text_searcher_test.py
+++ b/app/solr_query/tests/ht_full_text_searcher_test.py
@@ -1,7 +1,48 @@
 import os
+from unittest.mock import patch
 
 from ht_full_text_search.ht_full_text_searcher import HTFullTextSearcher
 from ht_search import config_search
+
+
+class TestRetrieveDocumentsFromFile:
+    """retrieve_documents_from_file's batching loop used to live entirely inside
+    `if len(list_ids) > 100:`, so a list of 100 or fewer ids silently yielded nothing instead
+    of one batch."""
+
+    @staticmethod
+    def _searcher():
+        return HTFullTextSearcher(solr_url="http://fake-solr", ht_search_query=None, environment="dev")
+
+    def test_yields_a_batch_for_100_or_fewer_ids(self):
+        searcher = self._searcher()
+        list_ids = [f"id_{i}" for i in range(50)]
+
+        with patch.object(searcher, "solr_result_output", return_value=(["doc"], ["debug"])) as mock_output:
+            batches = list(searcher.retrieve_documents_from_file(list_ids=list_ids))
+
+        assert batches == [(["doc"], ["debug"])]
+        mock_output.assert_called_once()
+        assert mock_output.call_args.kwargs["filter_dict"] == {"id": list_ids}
+
+    def test_yields_multiple_batches_over_100_ids(self):
+        searcher = self._searcher()
+        list_ids = [f"id_{i}" for i in range(150)]
+
+        with patch.object(searcher, "solr_result_output", return_value=(["doc"], ["debug"])) as mock_output:
+            batches = list(searcher.retrieve_documents_from_file(list_ids=list_ids))
+
+        assert len(batches) == 2
+        first_chunk = mock_output.call_args_list[0].kwargs["filter_dict"]["id"]
+        second_chunk = mock_output.call_args_list[1].kwargs["filter_dict"]["id"]
+        assert len(first_chunk) == 100
+        assert len(second_chunk) == 50
+
+    def test_empty_list_yields_nothing(self):
+        assert list(self._searcher().retrieve_documents_from_file(list_ids=[])) == []
+
+    def test_none_list_yields_nothing(self):
+        assert list(self._searcher().retrieve_documents_from_file(list_ids=None)) == []
 
 
 class TestHTFullTextSearcher:

--- a/libs/ht_search/src/ht_search/config_search.py
+++ b/libs/ht_search/src/ht_search/config_search.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 import os
 import sys
@@ -40,9 +41,10 @@ def default_solr_params(env: str = "prod"):
     :param env:
     :return:
     """
+    params = copy.deepcopy(DEFAULT_SOLR_PARAMS)
     if env == "prod":
-        add_shards(DEFAULT_SOLR_PARAMS)
-    return DEFAULT_SOLR_PARAMS
+        add_shards(params)
+    return params
 
 
 def add_shards(params: dict):

--- a/libs/ht_search/tests/config_search_test.py
+++ b/libs/ht_search/tests/config_search_test.py
@@ -1,0 +1,37 @@
+from ht_search.config_search import DEFAULT_SOLR_PARAMS, default_solr_params
+
+
+class TestDefaultSolrParams:
+    """default_solr_params() used to return a reference to the shared module-level
+    DEFAULT_SOLR_PARAMS dict. Callers (e.g. SolrExporter.run_cursor) mutate the dict they get
+    back with per-query values like 'q' and 'cursorMark', so a second call in the same process
+    inherited the first call's query and a stale cursor."""
+
+    def test_returns_a_fresh_dict_each_call(self):
+        first = default_solr_params(env="dev")
+        first["q"] = "title:first query"
+        first["cursorMark"] = "some-cursor-value"
+
+        second = default_solr_params(env="dev")
+
+        assert second is not first
+        assert "q" not in second
+        assert "cursorMark" not in second
+
+    def test_does_not_mutate_the_module_level_default(self):
+        params = default_solr_params(env="prod")
+        params["q"] = "title:another query"
+
+        assert "q" not in DEFAULT_SOLR_PARAMS
+        assert "shards" not in DEFAULT_SOLR_PARAMS
+
+    def test_prod_env_adds_shards_to_the_returned_copy_only(self):
+        params = default_solr_params(env="prod")
+
+        assert "shards" in params
+        assert "shards" not in DEFAULT_SOLR_PARAMS
+
+    def test_dev_env_does_not_add_shards(self):
+        params = default_solr_params(env="dev")
+
+        assert "shards" not in params


### PR DESCRIPTION
There are four bugs addressed:

Two bugs: KBART keyed results by stripped-zero ids but looked them up by the raw padded id, so every padded id landed in the error file even though its data was there. And default_solr_params() returned the shared dict by reference, so one query's params leaked into the next.

The other two: retriever's serial branch passed raw MySQL dicts where id strings were expected (hard TypeError). Full-text searcher's batching loop lived entirely inside if len(list_ids) > 100, so <=100 ids silently returned nothing.

Two new tests live under libs//app/data_operations, not used by CI yet. Verified locally for now.