### PR TITLE
ETT-1791 annotate app/data_operations for mypy --strict

### DIFF
--- a/app/data_operations/src/kbart_file_generator/kbart_file_generator.py
+++ b/app/data_operations/src/kbart_file_generator/kbart_file_generator.py
@@ -138,7 +138,7 @@ def filter_out_dates(value: str) -> str:
         return value
 
 
-def check_bib_fmt_field(title_dates: Mapping[str, object]) -> str:
+def check_bib_fmt_field(title_dates: Mapping[str, object] | None) -> str:
 
     if first_value((title_dates or {}).get("bib_fmt")) != "SE":
         return ""

--- a/app/data_operations/tests/test_kbart_file_generator.py
+++ b/app/data_operations/tests/test_kbart_file_generator.py
@@ -1,4 +1,5 @@
 import csv
+from collections.abc import Sequence
 from pathlib import Path
 
 import kbart_file_generator.kbart_file_generator as kbart_module
@@ -124,7 +125,9 @@ def test_generate_kbart_rows_matches_zero_padded_ids_to_stripped_lookup_keys(
     """Lookup results are keyed by catalog id with leading zeros stripped; catalog_ids from
     the input file are zero-padded."""
 
-    def fake_fetch_lookup_results_in_parallel(catalog_ids, batch_size=None):
+    def fake_fetch_lookup_results_in_parallel(
+        catalog_ids: Sequence[str], batch_size: int = 100
+    ) -> tuple[dict[str, dict[str, object]], dict[str, dict[str, object]]]:
         return (
             {
                 "9040": {

--- a/app/data_operations/tests/test_metadata_generator.py
+++ b/app/data_operations/tests/test_metadata_generator.py
@@ -11,7 +11,7 @@ from metadata_extractor.metadata_generator import (
     generate_dissertation_rows,
     record_matches,
 )
-from pymarc import Field, Record, Subfield
+from pymarc import Field, Indicators, Record, Subfield
 
 SAMPLE_RECORD = {
     "leader": "00000nam a2200000 a 4500",
@@ -59,23 +59,25 @@ def test_record_matches_detects_dissertation_keywords() -> None:
 def test_extract_identifiers() -> None:
 
     record = Record()
-    record.add_field(
+    record.add_field(  # type: ignore[no-untyped-call]
         Field(
             tag="035",
-            indicators=[" ", " "],
+            indicators=Indicators(" ", " "),
             subfields=[Subfield(code="a", value="(ProQuest)disstheses AAI999")],
         )
-    )  # type: ignore[no-untyped-call,arg-type]
-    record.add_field(
-        Field(tag="502", indicators=[" ", " "], subfields=[Subfield(code="o", value="AAI8999")])
-    )  # type: ignore[no-untyped-call,arg-type]
-    record.add_field(
+    )
+    record.add_field(  # type: ignore[no-untyped-call]
+        Field(
+            tag="502", indicators=Indicators(" ", " "), subfields=[Subfield(code="o", value="AAI8999")]
+        )
+    )
+    record.add_field(  # type: ignore[no-untyped-call]
         Field(
             tag="035",
-            indicators=[" ", " "],
+            indicators=Indicators(" ", " "),
             subfields=[Subfield(code="a", value="(MiU)990027275210106381")],
         )
-    )  # type: ignore[no-untyped-call,arg-type]
+    )
 
     identifiers = extract_identifiers(record)
     assert "(ProQuest)disstheses AAI999" in identifiers


### PR DESCRIPTION
Stacked on #27. Adds mypy --strict compliance for app/data_operations: type annotations for kbart_file_generator and tests, and the pymarc Indicators construction fix.